### PR TITLE
Fix token expiration handling

### DIFF
--- a/frontend/src/contexts/AppContext.jsx
+++ b/frontend/src/contexts/AppContext.jsx
@@ -62,6 +62,13 @@ export function AppProvider({ children }) {
         }
     }, [clearSession]);
 
+    // Verificar expiración de token en inicialización y cambios
+    useEffect(() => {
+        if (token && isTokenExpired(token)) {
+            handleSessionExpired();
+        }
+    }, [token, handleSessionExpired]);
+
     // --- Axios: token attach/interceptors ---
     useEffect(() => {
         const req = api.interceptors.request.use(


### PR DESCRIPTION
## Summary
- add missing token expiration check

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687479723778832ab1525645e49f4024